### PR TITLE
(koin) fix: fix get() called to nullable variable type exception

### DIFF
--- a/packages/koin/lib/src/definition/provider_definition.dart
+++ b/packages/koin/lib/src/definition/provider_definition.dart
@@ -195,9 +195,14 @@ class ProviderDefinition<T> {
 /// Converte the 'type' and 'qualifier'
 ///
 String indexKey(Type type, Qualifier? qualifier) {
+  var typeString = type.toString();
+  if (typeString.endsWith('?')) {
+    typeString = typeString.substring(0, typeString.length - 1);
+  }
+
   if (qualifier?.value != null) {
-    return '${type.toString()}::${qualifier?.value}';
+    return '$typeString::${qualifier?.value}';
   } else {
-    return type.toString();
+    return typeString;
   }
 }

--- a/packages/koin/test/core/instance_resolution_test.dart
+++ b/packages/koin/test/core/instance_resolution_test.dart
@@ -100,4 +100,16 @@ void main() {
     expect(component, isA<Component1>());
     expect(koin.get<ComponentInterface1>(named('2')), isA<Component2>());
   });
+
+  test('can resolve nullable type', () {
+    var koin = koinApplication((app) {
+      app.module(
+        module()..single<String>((scope) => 'test_string'),
+      );
+    }).koin;
+
+    // ignore: omit_local_variable_types
+    String? variable = koin.get();
+    expect(variable, equals('test_string'));
+  });
 }


### PR DESCRIPTION
After this change it is safe to use `get()` on nullable type variables.
Previously such interaction has throw `NoBeanDefFoundException`.

In Kotlin generic `T` type full name is not has '?' ending as it has in Dart language.
Because of that IMO we should use only non nullable type names for index keys.